### PR TITLE
Refine footer transition and styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,12 +1,4 @@
 /* SVG de montanhas no topo do footer */
-.footer {
-    position: relative;
-    background: transparent;
-    color: white;
-    padding: 0 0 0 0;
-    text-align: center;
-    overflow: hidden;
-}
 .footer-mountains {
     position: absolute;
     top: 0;
@@ -477,11 +469,13 @@ body {
 }
 
 .footer {
+    position: relative;
     background: var(--primary-color);
     color: white;
     padding: 3rem 0;
+    padding-top: 80px;
     text-align: center;
-    margin-top: 5rem;
+    overflow: hidden;
 }
 
 .contact-info {


### PR DESCRIPTION
- Removes the white strip between the main content and the footer by eliminating the footer's top margin.
- Uses the existing SVG mountain element to create a subtle, textured transition at the top of the footer.
- Adjusts footer padding to accommodate the SVG transition element, ensuring content is not obscured.
- Cleans up unused and conflicting CSS rules for the footer to improve code clarity.

This change addresses your feedback to create a more professional and seamless integration between the page background and the footer section.